### PR TITLE
build: Ensure `go env GOPATH`/bin is a directory before installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ std/build/std.js: std/*.fbs std/*.js std/package.json
 	std/generate.sh
 	cd std && npm run build
 
+D := $(shell go env GOPATH)/bin
 install: jk
-	cp jk `go env GOPATH`/bin
+	mkdir -p $(D)
+	cp jk $(D)
 
 build-image:
 	docker build -t quay.io/justkidding/build -f build/Dockerfile build/


### PR DESCRIPTION
If jk is the first binary to be installed there, the directoy may not exist.
Create it first!