### PR TITLE
build: Use go env GOOS and GOARCH when naming the release binary

### DIFF
--- a/run-release.sh
+++ b/run-release.sh
@@ -26,7 +26,7 @@ function upload() {
 
 }
 
-binary=jk-linux-amd64
+binary=jk-`go env GOOS`-`go env GOARCH`
 mv jk $binary
 
 echo "==> Uploading $binary"


### PR DESCRIPTION
This way this script should work on macOS as well!